### PR TITLE
[Fix] 시뮬레이터 판단하는 코드를 Xcode 16.3에서도 동작하도록 수정

### DIFF
--- a/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
+++ b/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
@@ -137,7 +137,11 @@ public enum PopupConfigure {
 
 public struct Platform {
     public static var isSimulator: Bool {
-        return TARGET_OS_SIMULATOR != 0 // Use this line in Xcode 7 or newer
+        #if targetEnvironment(simulator)
+        return true
+        #else
+        return false
+        #endif
     }
 }
 


### PR DESCRIPTION
# 어떤 PR인가요?

TLPhotosPickerViewController.swift 내부에 선언된 Platform.isSimulator가 내부에서 참조하는 TARGET_OS_SIMULATOR가 Xcode 16.3에서 사용할 수 없게 되어([TLPhotoPicker 내 관련 이슈](https://github.com/tilltue/TLPhotoPicker/issues/363), [PR](https://github.com/tilltue/TLPhotoPicker/pull/361)) 이를 수정합니다.