### PR TITLE
[Refactor] PR #16 코드 리뷰 반영 — 버그 수정 및 리팩토링

### DIFF
--- a/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
+++ b/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
@@ -224,13 +224,12 @@ open class TLPhotosPickerViewController: UIViewController {
     private var placeholderThumbnail: UIImage? = nil
     private var cameraImage: UIImage? = nil
     
-    // Multi-selection gesture
     private var panGestureRecognizer: UIPanGestureRecognizer?
     private var isMultiSelecting = false
     private var lastSelectedIndexPath: IndexPath?
     private var firstSelectedIndexPath: IndexPath?
     private var processedIndexPaths = Set<Int>()
-    private var isDeselectMode = false // Track if we're in deselect mode
+    private var isDeselectMode = false
     private let minimumPanDistance: CGFloat = 10.0
     
     deinit {
@@ -669,54 +668,36 @@ extension TLPhotosPickerViewController {
             resetMultiSelectState()
 
         case .changed:
-            // Check if minimum distance threshold has been met
             if !isMultiSelecting {
                 let translation = gesture.translation(in: self.collectionView)
                 let distance = sqrt(translation.x * translation.x + translation.y * translation.y)
-                
-                // Require minimum distance before activating multi-select
-                if distance < minimumPanDistance {
-                    return
-                }
-                
-                // Only activate multi-select for horizontal panning (not vertical scrolling)
+                if distance < minimumPanDistance { return }
+
                 let absX = abs(translation.x)
                 let absY = abs(translation.y)
-                if absX <= absY {
-                    // Vertical or diagonal movement - don't activate multi-select
-                    return
-                }
-                
-                // Activate multi-select mode
+                if absX <= absY { return }
+
                 isMultiSelecting = true
-                // Disable scrolling during multi-selection
                 collectionView.isScrollEnabled = false
             }
-            
+
             guard let indexPath = self.collectionView.indexPathForItem(at: location),
                   let collection = self.focusedCollection,
                   let cell = self.collectionView.cellForItem(at: indexPath) as? TLPhotoCollectionViewCell else {
                 return
             }
-            
-            if isCameraIndexPath(indexPath, in: collection) {
-                return
-            }
-            
-            // Store first selected index if not set
+
+            if isCameraIndexPath(indexPath, in: collection) { return }
+
             if firstSelectedIndexPath == nil {
                 firstSelectedIndexPath = indexPath
-                
-                // Determine mode based on first cell's selection state
                 if let asset = collection.getTLAsset(at: indexPath),
                    let phAsset = asset.phAsset {
                     isDeselectMode = selectedAssets.contains(where: { $0.phAsset == phAsset })
                 }
             }
-            
-            // Only process if we moved to a different cell
+
             if lastSelectedIndexPath != indexPath {
-                // Select all cells in rectangular region between first and current
                 selectCellsBetween(from: firstSelectedIndexPath!, to: indexPath)
                 lastSelectedIndexPath = indexPath
             }
@@ -731,17 +712,13 @@ extension TLPhotosPickerViewController {
     
     private func selectCellsBetween(from startIndexPath: IndexPath, to endIndexPath: IndexPath) {
         guard let collection = focusedCollection else { return }
-        
-        // Calculate current range
+
         let minRow = min(startIndexPath.row, endIndexPath.row)
         let maxRow = max(startIndexPath.row, endIndexPath.row)
         let currentRange = Set(minRow...maxRow)
-        
-        // Process cells that were in previous range but not in current range
         let toProcess = processedIndexPaths.subtracting(currentRange)
         for row in toProcess {
             let indexPath = IndexPath(row: row, section: endIndexPath.section)
-            
             let itemCount = collection.sections?[safe: indexPath.section]?.assets.count ?? collection.count
             guard row < itemCount else { continue }
             if isCameraIndexPath(indexPath, in: collection) { continue }
@@ -775,7 +752,6 @@ extension TLPhotosPickerViewController {
             }
         }
         
-        // Update processed index paths to current range
         processedIndexPaths = currentRange
     }
 }
@@ -1109,22 +1085,15 @@ extension TLPhotosPickerViewController: PHPhotoLibraryChangeObserver {
                         guard let `self` = self else { return }
                         self.focusedCollection?.fetchResult = changes.fetchResultAfterChanges
                         
-                        // 1. Delete
                         if let removed = changes.removedIndexes, removed.count > 0 {
-                            self.collectionView.deleteItems(at: removed.map { IndexPath(item: $0+addIndex, section:0) })
+                            self.collectionView.deleteItems(at: removed.map { IndexPath(item: $0+addIndex, section: 0) })
                         }
-                        
-                        // 2. Insert
                         if let inserted = changes.insertedIndexes, inserted.count > 0 {
-                            self.collectionView.insertItems(at: inserted.map { IndexPath(item: $0+addIndex, section:0) })
+                            self.collectionView.insertItems(at: inserted.map { IndexPath(item: $0+addIndex, section: 0) })
                         }
-                        
-                        // 3. Reload (using captured index paths)
                         if let changedIndexPaths = changedIndexPaths {
                             self.collectionView.reloadItems(at: changedIndexPaths)
                         }
-                        
-                        // 4. Move (must be last, as recommended by Apple)
                         changes.enumerateMoves { fromIndex, toIndex in
                             self.collectionView.moveItem(at: IndexPath(item: fromIndex + addIndex, section: 0),
                                                          to: IndexPath(item: toIndex + addIndex, section: 0))
@@ -1576,22 +1545,14 @@ extension TLPhotosPickerViewController: UIGestureRecognizerDelegate {
             let translation = pan.translation(in: collectionView)
             let velocity = pan.velocity(in: collectionView)
             
-            // Check both translation and velocity to determine direction early
-            let absTranslationX = abs(translation.x)
-            let absTranslationY = abs(translation.y)
-            let absVelocityX = abs(velocity.x)
-            let absVelocityY = abs(velocity.y)
-            
-            let isHorizontalTranslation = absTranslationX > absTranslationY
-            let isHorizontalVelocity = absVelocityX > absVelocityY
-
+            let isHorizontalTranslation = abs(translation.x) > abs(translation.y)
+            let isHorizontalVelocity = abs(velocity.x) > abs(velocity.y)
             return isHorizontalTranslation && isHorizontalVelocity
         }
         return true
     }
     
     public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
-        // Allow simultaneous recognition with collection view's pan gesture
         if gestureRecognizer == panGestureRecognizer {
             return otherGestureRecognizer == collectionView.panGestureRecognizer
         }

--- a/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
+++ b/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
@@ -1136,12 +1136,14 @@ extension TLPhotosPickerViewController: PHPhotoLibraryChangeObserver {
                     self.focusedCollection?.fetchResult = changes.fetchResultAfterChanges
                     self.reloadCollectionView()
                 }else {
-                    // Capture changedIndexes before any updates (Apple recommendation)
+                    // Capture changedIndexes before any updates (Apple recommendation).
+                    // Exclude indexes that are also being removed to prevent batch update conflict.
+                    let removedIndexes = changes.removedIndexes ?? IndexSet()
                     let changedIndexPaths: [IndexPath]? = {
-                        if let changed = changes.changedIndexes, changed.count > 0 {
-                            return changed.map { IndexPath(item: $0+addIndex, section:0) }
-                        }
-                        return nil
+                        guard let changed = changes.changedIndexes, changed.count > 0 else { return nil }
+                        let filtered = changed.filter { !removedIndexes.contains($0) }
+                        guard !filtered.isEmpty else { return nil }
+                        return filtered.map { IndexPath(item: $0+addIndex, section: 0) }
                     }()
                     
                     self.collectionView.performBatchUpdates({ [weak self] in

--- a/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
+++ b/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
@@ -639,6 +639,15 @@ extension TLPhotosPickerViewController {
     }
     
     // MARK: - Multi-Selection Gesture
+    private func resetMultiSelectState() {
+        isMultiSelecting = false
+        lastSelectedIndexPath = nil
+        firstSelectedIndexPath = nil
+        processedIndexPaths.removeAll()
+        isDeselectMode = false
+        collectionView.isScrollEnabled = true
+    }
+
     private func setupMultiSelectionGesture() {
         let panGesture = UIPanGestureRecognizer(target: self, action: #selector(handlePanGesture(_:)))
         panGesture.delegate = self
@@ -653,12 +662,8 @@ extension TLPhotosPickerViewController {
         
         switch gesture.state {
         case .began:
-            isMultiSelecting = false
-            lastSelectedIndexPath = nil
-            firstSelectedIndexPath = nil
-            processedIndexPaths.removeAll()
-            isDeselectMode = false
-            
+            resetMultiSelectState()
+
         case .changed:
             // Check if minimum distance threshold has been met
             if !isMultiSelecting {
@@ -715,14 +720,8 @@ extension TLPhotosPickerViewController {
             }
             
         case .ended, .cancelled:
-            isMultiSelecting = false
-            lastSelectedIndexPath = nil
-            firstSelectedIndexPath = nil
-            processedIndexPaths.removeAll()
-            isDeselectMode = false
-            // Re-enable scrolling when multi-selection ends
-            collectionView.isScrollEnabled = true
-            
+            resetMultiSelectState()
+
         default:
             break
         }
@@ -1094,13 +1093,7 @@ extension TLPhotosPickerViewController: PHPhotoLibraryChangeObserver {
     public func photoLibraryDidChange(_ changeInstance: PHChange) {
         let addIndex = self.focusedCollection?.useCameraButton == true ? 1 : 0
         DispatchQueue.main.async {
-            self.isMultiSelecting = false
-            self.lastSelectedIndexPath = nil
-            self.firstSelectedIndexPath = nil
-            self.processedIndexPaths.removeAll()
-            self.isDeselectMode = false
-            // Re-enable scrolling if it was disabled during multi-selection
-            self.collectionView.isScrollEnabled = true
+            self.resetMultiSelectState()
             guard let changes = self.getChanges(changeInstance) else {
                 return
             }

--- a/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
+++ b/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
@@ -639,6 +639,10 @@ extension TLPhotosPickerViewController {
     }
     
     // MARK: - Multi-Selection Gesture
+    private func isCameraIndexPath(_ indexPath: IndexPath, in collection: TLAssetsCollection) -> Bool {
+        return collection.useCameraButton && indexPath.section == 0 && indexPath.row == 0
+    }
+
     private func resetMultiSelectState() {
         isMultiSelecting = false
         lastSelectedIndexPath = nil
@@ -695,9 +699,7 @@ extension TLPhotosPickerViewController {
                 return
             }
             
-            // Skip camera cell
-            let isCameraRow = collection.useCameraButton && indexPath.section == 0 && indexPath.row == 0
-            if isCameraRow {
+            if isCameraIndexPath(indexPath, in: collection) {
                 return
             }
             
@@ -727,10 +729,6 @@ extension TLPhotosPickerViewController {
         }
     }
     
-    private func toggleSelectionForMultiSelect(for cell: TLPhotoCollectionViewCell, at indexPath: IndexPath) {
-        toggleSelection(for: cell, at: indexPath, isMultiSelectMode: true)
-    }
-    
     private func selectCellsBetween(from startIndexPath: IndexPath, to endIndexPath: IndexPath) {
         guard let collection = focusedCollection else { return }
         
@@ -744,66 +742,35 @@ extension TLPhotosPickerViewController {
         for row in toProcess {
             let indexPath = IndexPath(row: row, section: endIndexPath.section)
             
-            // Check if this index path is valid
             let itemCount = collection.sections?[safe: indexPath.section]?.assets.count ?? collection.count
             guard row < itemCount else { continue }
-            
-            // Skip camera cell
-            let isCameraRow = collection.useCameraButton && indexPath.section == 0 && indexPath.row == 0
-            if isCameraRow { continue }
-            
-            // Reverse the operation for cells outside current range
+            if isCameraIndexPath(indexPath, in: collection) { continue }
+
             if let cell = collectionView.cellForItem(at: indexPath) as? TLPhotoCollectionViewCell,
                let asset = collection.getTLAsset(at: indexPath),
                let phAsset = asset.phAsset {
                 let isSelected = selectedAssets.contains(where: { $0.phAsset == phAsset })
-                
-                if isDeselectMode {
-                    // In deselect mode, re-select cells outside range
-                    if !isSelected {
-                        toggleSelectionForMultiSelect(for: cell, at: indexPath)
-                    }
-                } else {
-                    // In select mode, deselect cells outside range
-                    if isSelected {
-                        toggleSelectionForMultiSelect(for: cell, at: indexPath)
-                    }
+                if isDeselectMode ? !isSelected : isSelected {
+                    toggleSelection(for: cell, at: indexPath, isMultiSelectMode: true)
                 }
             }
         }
-        
-        // Process cells in current range
+
         for row in currentRange {
             let indexPath = IndexPath(row: row, section: endIndexPath.section)
-            
-            if processedIndexPaths.contains(row) {
-                continue
-            }
-            
-            // Check if this index path is valid
+
+            if processedIndexPaths.contains(row) { continue }
+
             let itemCount = collection.sections?[safe: indexPath.section]?.assets.count ?? collection.count
             guard row < itemCount else { continue }
-            
-            // Skip camera cell
-            let isCameraRow = collection.useCameraButton && indexPath.section == 0 && indexPath.row == 0
-            if isCameraRow { continue }
-            
-            // Apply operation based on mode
+            if isCameraIndexPath(indexPath, in: collection) { continue }
+
             if let cell = collectionView.cellForItem(at: indexPath) as? TLPhotoCollectionViewCell,
                let asset = collection.getTLAsset(at: indexPath),
                let phAsset = asset.phAsset {
                 let isSelected = selectedAssets.contains(where: { $0.phAsset == phAsset })
-                
-                if isDeselectMode {
-                    // Deselect if currently selected
-                    if isSelected {
-                        toggleSelectionForMultiSelect(for: cell, at: indexPath)
-                    }
-                } else {
-                    // Select if currently not selected
-                    if !isSelected {
-                        toggleSelectionForMultiSelect(for: cell, at: indexPath)
-                    }
+                if isDeselectMode ? isSelected : !isSelected {
+                    toggleSelection(for: cell, at: indexPath, isMultiSelectMode: true)
                 }
             }
         }

--- a/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
+++ b/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
@@ -777,8 +777,7 @@ extension TLPhotosPickerViewController {
         for row in currentRange {
             let indexPath = IndexPath(row: row, section: endIndexPath.section)
             
-            // Skip if already processed and in current range
-            if processedIndexPaths.contains(row) && currentRange.contains(row) {
+            if processedIndexPaths.contains(row) {
                 continue
             }
             

--- a/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
+++ b/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
@@ -713,6 +713,8 @@ extension TLPhotosPickerViewController {
     private func selectCellsBetween(from startIndexPath: IndexPath, to endIndexPath: IndexPath) {
         guard let collection = focusedCollection else { return }
 
+        let selectedIdentifiers = Set(selectedAssets.compactMap { $0.phAsset?.localIdentifier })
+
         let minRow = min(startIndexPath.row, endIndexPath.row)
         let maxRow = max(startIndexPath.row, endIndexPath.row)
         let currentRange = Set(minRow...maxRow)
@@ -725,8 +727,8 @@ extension TLPhotosPickerViewController {
 
             if let cell = collectionView.cellForItem(at: indexPath) as? TLPhotoCollectionViewCell,
                let asset = collection.getTLAsset(at: indexPath),
-               let phAsset = asset.phAsset {
-                let isSelected = selectedAssets.contains(where: { $0.phAsset == phAsset })
+               let localID = asset.phAsset?.localIdentifier {
+                let isSelected = selectedIdentifiers.contains(localID)
                 if isDeselectMode ? !isSelected : isSelected {
                     toggleSelection(for: cell, at: indexPath, isMultiSelectMode: true)
                 }
@@ -744,14 +746,14 @@ extension TLPhotosPickerViewController {
 
             if let cell = collectionView.cellForItem(at: indexPath) as? TLPhotoCollectionViewCell,
                let asset = collection.getTLAsset(at: indexPath),
-               let phAsset = asset.phAsset {
-                let isSelected = selectedAssets.contains(where: { $0.phAsset == phAsset })
+               let localID = asset.phAsset?.localIdentifier {
+                let isSelected = selectedIdentifiers.contains(localID)
                 if isDeselectMode ? isSelected : !isSelected {
                     toggleSelection(for: cell, at: indexPath, isMultiSelectMode: true)
                 }
             }
         }
-        
+
         processedIndexPaths = currentRange
     }
 }

--- a/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
+++ b/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
@@ -1621,11 +1621,10 @@ extension TLPhotosPickerViewController: UIGestureRecognizerDelegate {
             let absVelocityX = abs(velocity.x)
             let absVelocityY = abs(velocity.y)
             
-            // Allow if horizontal movement or velocity is greater than vertical
             let isHorizontalTranslation = absTranslationX > absTranslationY
             let isHorizontalVelocity = absVelocityX > absVelocityY
-            
-            return isHorizontalTranslation || isHorizontalVelocity
+
+            return isHorizontalTranslation && isHorizontalVelocity
         }
         return true
     }


### PR DESCRIPTION
## Summary

PR #16 (drag to toggle multi selection) 코드 리뷰에서 지적된 항목 중 타당성이 확인된 항목을 반영합니다.

### Bug Fixes
- **`gestureRecognizerShouldBegin` OR → AND**: velocity는 수평이지만 translation이 수직인 대각선 빠른 스와이프에서 멀티셀렉트가 오활성화될 수 있던 조건 수정
- **Batch update 충돌 방지**: `removedIndexes`와 겹치는 항목을 `changedIndexPaths`에서 필터링해 동일 IndexPath에 `deleteItems` + `reloadItems`가 함께 실행되는 경우 방어
- **dead condition 제거**: `for row in currentRange` 루프 내 `currentRange.contains(row)`는 항상 `true` — 불필요한 조건 제거

### Refactoring
- **`resetMultiSelectState()` 추출**: `.began`, `.ended/.cancelled`, `photoLibraryDidChange` 3곳에 동일하게 복사된 리셋 블록 통합
- **`isCameraIndexPath(_:in:)` 헬퍼 추출**: 3곳에 인라인으로 복사된 카메라 셀 체크 조건 통합
- **`toggleSelectionForMultiSelect` 래퍼 제거**: 단일 라인 래퍼 제거 후 콜 사이트에서 직접 호출
- **불필요한 인라인 주석 제거**: 코드가 이미 설명하는 주석 삭제

### Performance
- **`selectCellsBetween` O(n) → O(1) 조회**: touch-move 핫패스에서 `selectedAssets.contains(where:)` 배열 선형 탐색을 메서드 진입 시 `localIdentifier` 기반 `Set` 한 번 구성으로 대체

### 리뷰 오판정으로 미반영한 항목
- `photoLibraryDidChange` 시맨틱 변경: `useCameraButton`은 camera roll에만 설정되므로 실제 버그 아님
- `isMultiSelecting` 대체 제안: `isMultiSelecting = true`와 `firstSelectedIndexPath` 설정 시점이 달라 대체 불가

## Test plan
- [ ] 수평 드래그 → 멀티셀렉트 정상 활성화
- [ ] 수직 스크롤 → 멀티셀렉트 미활성화
- [ ] 대각선 빠른 스와이프 → 멀티셀렉트 미활성화 (OR → AND 수정 검증)
- [ ] 드래그 중 선택/해제 모드 정상 동작
- [ ] 포토 라이브러리 변경(사진 삭제/추가) 후 크래시 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 다중 선택 처리 로직을 최적화하여 코드 중복을 제거했습니다.
  * 제스처 인식 정확도를 개선하여 사진 라이브러리 탐색 시 더욱 정확한 터치 감지가 가능해졌습니다.
  * 사진 라이브러리 변경 감지 시 사용자 인터페이스 업데이트 안정성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->